### PR TITLE
fix: flaky `navigate right` when changing `cell-width`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,3 @@
-use polars::prelude::file;
 use ratatui::{
     Frame, Terminal,
     layout::{Constraint, Layout},
@@ -12,14 +11,14 @@ use crate::{
     controller::Controller,
     df::state::DataFrameState,
     errors::DoraResults,
-    input::{self, Control, InputHandler},
+    input::{Control, InputHandler},
     io::{
         ExcelReader, ExcelSheetSelectorPage, ExcelSheetSelectorWidgetState,
         get_cursor_from_any_path,
     },
     mode::AppMode,
     mode_banner::ModeBanner,
-    page::{self, PageState},
+    page::{PageState},
     search::state::SearchResultState,
     table::table_ui::TableUI,
     utils::area::horizontal_pad_area,

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -1,4 +1,3 @@
-use crate::errors::DoraErrors;
 
 use super::{dotconfig::read_config_file, serde::Config};
 

--- a/src/config/dotconfig.rs
+++ b/src/config/dotconfig.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs::{self, File, create_dir},
+    fs::{self, File},
     io::Read,
     path::{Path, PathBuf},
 };

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -96,7 +96,7 @@ impl Controller {
                 let col_view_slice = df_state.get_col_view_slice();
                 let slice_length = col_view_slice[1] - col_view_slice[0];
                 let df_max_cols = df_state.get_df_shape().1;
-                if *cursor_x == (slice_length - 1) {
+                if *cursor_x >= ((slice_length-1) - 1) {
                     if col_view_slice[1] > df_max_cols {
                     }
                     // reached the very end of the table

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -5,7 +5,6 @@ use crate::{
     commands::controller::CommandHandler,
     df::state::CursorFocus,
     input::{BufferState, Control},
-    io::read_excel_from_any_path,
     mode::AppMode,
     page::PageState,
     search::{

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -93,13 +93,12 @@ impl Controller {
             Control::ScrollRight => {
                 df_state.set_cursor_focus(CursorFocus::Column);
                 let cursor_x = df_state.get_cursor_x();
+                let cols_renderable = df_state.cols_rendered;
                 let col_view_slice = df_state.get_col_view_slice();
-                // println!("{},{}", col_view_slice[0], col_view_slice[1]);
-                let slice_length = col_view_slice[1] - col_view_slice[0];
                 let df_max_cols = df_state.get_df_shape().1;
-                if *cursor_x >= ((slice_length-1) - 1) {
-                    // println!("{},{},{},{}", cursor_x, col_view_slice[0], col_view_slice[1], slice_length);
-                    if col_view_slice[1] > df_max_cols {
+                if *cursor_x >= (cols_renderable-1) {
+                    // println!("{},{},{},{},{}", cursor_x, col_view_slice[0], col_view_slice[1], cols_renderable, df_max_cols);
+                    if col_view_slice[1] >= df_max_cols {
                     }
                     // reached the very end of the table
                     else {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -94,9 +94,11 @@ impl Controller {
                 df_state.set_cursor_focus(CursorFocus::Column);
                 let cursor_x = df_state.get_cursor_x();
                 let col_view_slice = df_state.get_col_view_slice();
+                // println!("{},{}", col_view_slice[0], col_view_slice[1]);
                 let slice_length = col_view_slice[1] - col_view_slice[0];
                 let df_max_cols = df_state.get_df_shape().1;
                 if *cursor_x >= ((slice_length-1) - 1) {
+                    // println!("{},{},{},{}", cursor_x, col_view_slice[0], col_view_slice[1], slice_length);
                     if col_view_slice[1] > df_max_cols {
                     }
                     // reached the very end of the table

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,16 +1,24 @@
 use polars::prelude::DataType;
 
 use crate::{
-    app::App, commands::controller::CommandHandler, df::state::CursorFocus, input::{BufferState, Control}, io::read_excel_from_any_path, mode::AppMode, page::PageState, search::{
+    app::App,
+    commands::controller::CommandHandler,
+    df::state::CursorFocus,
+    input::{BufferState, Control},
+    io::read_excel_from_any_path,
+    mode::AppMode,
+    page::PageState,
+    search::{
         approximate_substring_v1::SimpleApproximateSearch,
         controller::shift_current_result_cursor_value_into_view,
         search::par_find_substring_matches,
         traits::{AnySearchResult, SearchAlgorithmImplementations},
-    }, table::controller::{
+    },
+    table::controller::{
         shift_column_cursor_left, shift_column_cursor_right, shift_displayed_df_value_slice_down,
         shift_displayed_df_value_slice_left, shift_displayed_df_value_slice_right,
         shift_displayed_df_value_slice_up, shift_row_cursor_down, shift_row_cursor_up,
-    }
+    },
 };
 
 // given input,
@@ -96,7 +104,7 @@ impl Controller {
                 let cols_renderable = df_state.cols_rendered;
                 let col_view_slice = df_state.get_col_view_slice();
                 let df_max_cols = df_state.get_df_shape().1;
-                if *cursor_x >= (cols_renderable-1) {
+                if *cursor_x >= (cols_renderable - 1) {
                     // println!("{},{},{},{},{}", cursor_x, col_view_slice[0], col_view_slice[1], cols_renderable, df_max_cols);
                     if col_view_slice[1] >= df_max_cols {
                     }

--- a/src/df/state.rs
+++ b/src/df/state.rs
@@ -187,8 +187,11 @@ impl DataFrameState {
         let cols_renderable =
             (((table_area[1] / config_state.cell_width)as f64).floor() as u16).min(MAX_COLS_RENDERED as u16);
 
-        self.rows_rendered = rows_renderable;
-        self.cols_rendered = cols_renderable;
+        let (table_rows, table_cols) = self.get_df_shape();
+        self.rows_rendered = rows_renderable
+            .min(table_rows);
+        self.cols_rendered = cols_renderable
+            .min(table_cols);
     }
     pub fn recalculate_view_slices(&mut self) {
         ////////////////////////////////////

--- a/src/df/state.rs
+++ b/src/df/state.rs
@@ -224,11 +224,8 @@ impl DataFrameState {
             curr_col_view_slice[0],
             (curr_col_view_slice[0]+self.cols_rendered).min(max_cols_in_table),
         ];
-        // self.row_view_slice = new_row_view_slice;
-        // self.col_view_slice = new_col_view_slice;
         self.set_col_view_slice(new_col_view_slice);
         self.set_row_view_slice(new_row_view_slice);
-        // println!("rendered {},{}", self.rows_rendered, self.cols_rendered);
 
         // for simplicitys sake
         // just set the cursor to 0

--- a/src/df/state.rs
+++ b/src/df/state.rs
@@ -184,7 +184,7 @@ impl DataFrameState {
             .min(MAX_ROWS_RENDERED as u16);
 
         let cols_renderable =
-            (table_area[1] / config_state.cell_width).min(MAX_COLS_RENDERED as u16);
+            ((table_area[1] / config_state.cell_width)-minus_one_for_good_luck_because_it_needs_padding).min(MAX_COLS_RENDERED as u16);
 
         self.rows_rendered = rows_renderable;
         self.cols_rendered = cols_renderable;

--- a/src/df/state.rs
+++ b/src/df/state.rs
@@ -1,5 +1,9 @@
 // use polars::frame::DataFrame;
-use crate::{config::ConfigState, io::{read_excel_from_any_path, read_from_any_path}, table::header::Header};
+use crate::{
+    config::ConfigState,
+    io::{read_excel_from_any_path, read_from_any_path},
+    table::header::Header,
+};
 use polars::prelude::*;
 
 // only use these as initialisation values
@@ -28,8 +32,8 @@ pub struct DataFrameState {
     // not sure if it should be owned here
     // but we figure it out later.
     ///////////////////////////////////////
-    row_view_slice: [u16; 2],  // the current viewable slice.
-    col_view_slice: [u16; 2],  // the current viewable slice.
+    row_view_slice: [u16; 2], // the current viewable slice.
+    col_view_slice: [u16; 2], // the current viewable slice.
     // !!!!NOTE CURSORS ARE RELATIVE TO THE VIEW SLICE!!!!!
     cursor_x: u16, // dataframe cursor for col NOTE: is limited by the number of columns renderable
     cursor_y: u16, // dataframe cursor for row NOTE: is limited by the number of rows renderable
@@ -68,13 +72,9 @@ impl DataFrameState {
     // given an arbitrary df
     // set Df state's df
     // this is particularly useful
-    // for 
+    // for
     pub fn collect_from_excel_sheet(&mut self, sheet_index: usize) {
-        let df = read_excel_from_any_path(
-            &self.source_path,
-            sheet_index,
-        )
-        .unwrap();
+        let df = read_excel_from_any_path(&self.source_path, sheet_index).unwrap();
         self.dataframe = Some(df);
     }
 
@@ -178,23 +178,17 @@ impl DataFrameState {
         // calculate the number of rows  //
         // and columns we can render     //
         ///////////////////////////////////
-        let rows_renderable = 
-            ((
-                ((table_area[0] - config_state.header_height) / config_state.cell_height) as f64)
-                .floor() as u16
-            ).min(MAX_ROWS_RENDERED as u16);
+        let rows_renderable = ((((table_area[0] - config_state.header_height)
+            / config_state.cell_height) as f64)
+            .floor() as u16)
+            .min(MAX_ROWS_RENDERED as u16);
 
-        let cols_renderable =
-            ((
-                (table_area[1] / config_state.cell_width) as f64)
-                .floor() as u16
-            ).min(MAX_COLS_RENDERED as u16);
+        let cols_renderable = (((table_area[1] / config_state.cell_width) as f64).floor() as u16)
+            .min(MAX_COLS_RENDERED as u16);
 
         let (table_rows, table_cols) = self.get_df_shape();
-        self.rows_rendered = rows_renderable
-            .min(table_rows);
-        self.cols_rendered = cols_renderable
-            .min(table_cols);
+        self.rows_rendered = rows_renderable.min(table_rows);
+        self.cols_rendered = cols_renderable.min(table_cols);
     }
     pub fn recalculate_view_slices(&mut self) {
         ////////////////////////////////////
@@ -221,11 +215,11 @@ impl DataFrameState {
         //    actual table bounds
         let new_row_view_slice = [
             curr_row_view_slice[0],
-            (curr_row_view_slice[0]+self.rows_rendered).min(max_rows_in_table),
+            (curr_row_view_slice[0] + self.rows_rendered).min(max_rows_in_table),
         ];
         let new_col_view_slice = [
             curr_col_view_slice[0],
-            (curr_col_view_slice[0]+self.cols_rendered).min(max_cols_in_table),
+            (curr_col_view_slice[0] + self.cols_rendered).min(max_cols_in_table),
         ];
         self.set_col_view_slice(new_col_view_slice);
         self.set_row_view_slice(new_row_view_slice);
@@ -242,7 +236,6 @@ impl DataFrameState {
         if self.cursor_y >= self.rows_rendered {
             self.cursor_y = 0;
         }
-
     }
 
     pub fn refresh_renderable_table_size(&mut self, config_state: &ConfigState) {
@@ -269,7 +262,7 @@ impl DataFrameState {
         &self.cursor_x
     }
     pub fn set_cursor_x(&mut self, cursor_x: u16) {
-        if cursor_x as u16 > self.cols_rendered{
+        if cursor_x as u16 > self.cols_rendered {
             self.cursor_x = self.cols_rendered;
             return;
         }

--- a/src/df/state.rs
+++ b/src/df/state.rs
@@ -225,7 +225,7 @@ impl DataFrameState {
         // self.col_view_slice = new_col_view_slice;
         self.set_col_view_slice(new_col_view_slice);
         self.set_row_view_slice(new_row_view_slice);
-        println!("rendered {},{}", self.rows_rendered, self.cols_rendered);
+        // println!("rendered {},{}", self.rows_rendered, self.cols_rendered);
         // bound the cursors to be the upper bound
         // no need to do for lower bound since its lower bound centric
         // meaning its impossible for the lower bound to be mutated in

--- a/src/df/state.rs
+++ b/src/df/state.rs
@@ -178,11 +178,11 @@ impl DataFrameState {
         // calculate the number of rows  //
         // and columns we can render     //
         ///////////////////////////////////
-        let minus_one_for_good_luck_because_it_needs_padding = 1;
-        let rows_renderable = ((table_area[0] - config_state.header_height)
-            / config_state.cell_height
-            - minus_one_for_good_luck_because_it_needs_padding)
-            .min(MAX_ROWS_RENDERED as u16);
+        let rows_renderable = 
+            ((
+                ((table_area[0] - config_state.header_height) / config_state.cell_height) as f64)
+                .floor() as u16
+            ).min(MAX_ROWS_RENDERED as u16);
 
         let cols_renderable =
             (((table_area[1] / config_state.cell_width)as f64).floor() as u16).min(MAX_COLS_RENDERED as u16);

--- a/src/df/state.rs
+++ b/src/df/state.rs
@@ -4,9 +4,9 @@ use polars::prelude::*;
 
 // only use these as initialisation values
 // we will update dynamically later.
-const SLICE_SIZE: i64 = 50;
-const MAX_ROWS_RENDERED: i64 = SLICE_SIZE;
-const MAX_COLS_RENDERED: i64 = 10;
+const SLICE_SIZE: u16 = 50;
+const MAX_ROWS_RENDERED: u16 = SLICE_SIZE;
+const MAX_COLS_RENDERED: u16 = 10;
 
 const NULL_DF_ERR: &'static str = "Dataframe State's Dataframe attribute is None.";
 
@@ -28,10 +28,10 @@ pub struct DataFrameState {
     // not sure if it should be owned here
     // but we figure it out later.
     ///////////////////////////////////////
-    row_view_slice: [i64; 2],  // the current viewable slice.
-    col_view_slice: [i64; 2],  // the current viewable slice.
-    cursor_x: i64, // dataframe cursor for col NOTE: is limited by the number of columns renderable
-    cursor_y: i64, // dataframe cursor for row NOTE: is limited by the number of rows renderable
+    row_view_slice: [u16; 2],  // the current viewable slice.
+    col_view_slice: [u16; 2],  // the current viewable slice.
+    cursor_x: u16, // dataframe cursor for col NOTE: is limited by the number of columns renderable
+    cursor_y: u16, // dataframe cursor for row NOTE: is limited by the number of rows renderable
     cursor_focus: CursorFocus, // dataframe cursor focus on row or column (renders different highlights)
 
     // other UI state
@@ -78,11 +78,11 @@ impl DataFrameState {
     }
 
     // height, width
-    pub fn get_df_shape(&self) -> (i64, i64) {
+    pub fn get_df_shape(&self) -> (u16, u16) {
         let df = self.dataframe.as_ref().expect(NULL_DF_ERR);
 
         let shape = df.shape();
-        (shape.0 as i64, shape.1 as i64)
+        (shape.0 as u16, shape.1 as u16)
     }
 
     pub fn get_headers(&self) -> Vec<Header> {
@@ -149,11 +149,11 @@ impl DataFrameState {
         df.column(name).unwrap()
     }
 
-    pub fn get_column_by_index(&self, index: i64) -> Option<&Column> {
+    pub fn get_column_by_index(&self, index: u16) -> Option<&Column> {
         let df = self.dataframe.as_ref().expect(NULL_DF_ERR);
         let headers = self.get_headers();
         for (idx, col_name) in headers.iter().enumerate() {
-            if (idx as i64) == index {
+            if (idx as u16) == index {
                 return Some(df.column(&col_name.name).unwrap());
             }
         }
@@ -194,9 +194,9 @@ impl DataFrameState {
         // update row and col view slices //
         ////////////////////////////////////
         self.row_view_slice[0] = self.cursor_y;
-        self.row_view_slice[1] = self.cursor_y + self.rows_rendered as i64;
+        self.row_view_slice[1] = self.cursor_y + self.rows_rendered;
         self.col_view_slice[0] = self.cursor_x;
-        self.col_view_slice[1] = self.cursor_x + self.cols_rendered as i64;
+        self.col_view_slice[1] = self.cursor_x + self.cols_rendered;
     }
 
     pub fn refresh_renderable_table_size(&mut self, config_state: &ConfigState) {
@@ -205,34 +205,34 @@ impl DataFrameState {
     }
 
     // setter getters
-    pub fn get_row_view_slice(&self) -> &[i64; 2] {
+    pub fn get_row_view_slice(&self) -> &[u16; 2] {
         &self.row_view_slice
     }
-    pub fn set_row_view_slice(&mut self, new_indices: [i64; 2]) {
+    pub fn set_row_view_slice(&mut self, new_indices: [u16; 2]) {
         self.row_view_slice = new_indices;
     }
 
-    pub fn get_col_view_slice(&self) -> &[i64; 2] {
+    pub fn get_col_view_slice(&self) -> &[u16; 2] {
         &self.col_view_slice
     }
-    pub fn set_col_view_slice(&mut self, new_indices: [i64; 2]) {
+    pub fn set_col_view_slice(&mut self, new_indices: [u16; 2]) {
         self.col_view_slice = new_indices;
     }
 
-    pub fn get_cursor_x(&self) -> &i64 {
+    pub fn get_cursor_x(&self) -> &u16 {
         &self.cursor_x
     }
-    pub fn set_cursor_x(&mut self, cursor_x: i64) {
-        if cursor_x > MAX_COLS_RENDERED {
-            self.cursor_x = MAX_COLS_RENDERED;
+    pub fn set_cursor_x(&mut self, cursor_x: u16) {
+        if cursor_x as u16 > self.cols_rendered{
+            self.cursor_x = self.cols_rendered;
             return;
         }
         self.cursor_x = cursor_x;
     }
-    pub fn get_cursor_y(&self) -> &i64 {
+    pub fn get_cursor_y(&self) -> &u16 {
         &self.cursor_y
     }
-    pub fn set_cursor_y(&mut self, cursor_y: i64) {
+    pub fn set_cursor_y(&mut self, cursor_y: u16) {
         // limit the max y to be MAX_ROWS Rendered
         if cursor_y > MAX_ROWS_RENDERED {
             self.cursor_y = MAX_ROWS_RENDERED;

--- a/src/df/state.rs
+++ b/src/df/state.rs
@@ -194,10 +194,41 @@ impl DataFrameState {
         ////////////////////////////////////
         // update row and col view slices //
         ////////////////////////////////////
-        self.row_view_slice[0] = self.cursor_y;
-        self.row_view_slice[1] = self.cursor_y + self.rows_rendered;
-        self.col_view_slice[0] = self.cursor_x;
-        self.col_view_slice[1] = self.cursor_x + self.cols_rendered;
+        //
+        // keeping old implementation for now
+        // previous implementation was cursor centric
+        // now we are view slice centric
+        // and adjust the cursor to be within the bounds
+        // self.row_view_slice[0] = self.cursor_y;
+        // self.row_view_slice[1] = self.cursor_y + self.rows_rendered;
+        // self.col_view_slice[0] = self.cursor_x;
+        // self.col_view_slice[1] = self.cursor_x + self.cols_rendered;
+
+        let curr_row_view_slice = self.row_view_slice.clone();
+        let curr_col_view_slice = self.col_view_slice.clone();
+        let new_row_view_slice = [
+            curr_row_view_slice[0],
+            curr_row_view_slice[0]+self.rows_rendered,
+        ];
+        let new_col_view_slice = [
+            curr_col_view_slice[0],
+            curr_col_view_slice[0]+self.rows_rendered,
+        ];
+        self.row_view_slice = new_row_view_slice;
+        self.col_view_slice = new_col_view_slice;
+
+        // bound the cursors to be the upper bound
+        // no need to do for lower bound since its lower bound centric
+        // meaning its impossible for the lower bound to be mutated in
+        // this function, we take it as the starting point for calculations
+
+        // if self.cursor_x > self.cols_rendered {
+        //     self.cursor_x = self.cols_rendered
+        // }
+        // if self.cursor_y > self.rows_rendered {
+        //     self.cursor_y = self.rows_rendered
+        // }
+
     }
 
     pub fn refresh_renderable_table_size(&mut self, config_state: &ConfigState) {

--- a/src/df/state.rs
+++ b/src/df/state.rs
@@ -226,17 +226,19 @@ impl DataFrameState {
         self.set_col_view_slice(new_col_view_slice);
         self.set_row_view_slice(new_row_view_slice);
         // println!("rendered {},{}", self.rows_rendered, self.cols_rendered);
-        // bound the cursors to be the upper bound
-        // no need to do for lower bound since its lower bound centric
-        // meaning its impossible for the lower bound to be mutated in
-        // this function, we take it as the starting point for calculations
 
-        // if self.cursor_x > self.cols_rendered {
-        //     self.cursor_x = self.cols_rendered
-        // }
-        // if self.cursor_y > self.rows_rendered {
-        //     self.cursor_y = self.rows_rendered
-        // }
+        // for simplicitys sake
+        // just set the cursor to 0
+        // if the user decided to change size mid navigation
+        // itll be annoying but not the worst
+        // we just gotta acknowledge that its view slice first.
+        // this occurs when you resize the cells
+        if self.cursor_x >= self.cols_rendered {
+            self.cursor_x = 0;
+        }
+        if self.cursor_y >= self.rows_rendered {
+            self.cursor_y = 0;
+        }
 
     }
 

--- a/src/df/state.rs
+++ b/src/df/state.rs
@@ -30,6 +30,7 @@ pub struct DataFrameState {
     ///////////////////////////////////////
     row_view_slice: [u16; 2],  // the current viewable slice.
     col_view_slice: [u16; 2],  // the current viewable slice.
+    // !!!!NOTE CURSORS ARE RELATIVE TO THE VIEW SLICE!!!!!
     cursor_x: u16, // dataframe cursor for col NOTE: is limited by the number of columns renderable
     cursor_y: u16, // dataframe cursor for row NOTE: is limited by the number of rows renderable
     cursor_focus: CursorFocus, // dataframe cursor focus on row or column (renders different highlights)

--- a/src/df/state.rs
+++ b/src/df/state.rs
@@ -222,7 +222,7 @@ impl DataFrameState {
         ];
         let new_col_view_slice = [
             curr_col_view_slice[0],
-            (curr_col_view_slice[0]+self.rows_rendered).min(max_cols_in_table),
+            (curr_col_view_slice[0]+self.cols_rendered).min(max_cols_in_table),
         ];
         // self.row_view_slice = new_row_view_slice;
         // self.col_view_slice = new_col_view_slice;

--- a/src/df/state.rs
+++ b/src/df/state.rs
@@ -206,13 +206,20 @@ impl DataFrameState {
 
         let curr_row_view_slice = self.row_view_slice.clone();
         let curr_col_view_slice = self.col_view_slice.clone();
+        // bound by max table size
+        let max_cols_in_table = self.get_df_shape().1;
+        let max_rows_in_table = self.get_df_shape().0;
+
+        // generate new row sizes bounded by:
+        //    renderable sizes
+        //    actual table bounds
         let new_row_view_slice = [
             curr_row_view_slice[0],
-            curr_row_view_slice[0]+self.rows_rendered,
+            (curr_row_view_slice[0]+self.rows_rendered).min(max_rows_in_table),
         ];
         let new_col_view_slice = [
             curr_col_view_slice[0],
-            curr_col_view_slice[0]+self.rows_rendered,
+            (curr_col_view_slice[0]+self.rows_rendered).min(max_cols_in_table),
         ];
         self.row_view_slice = new_row_view_slice;
         self.col_view_slice = new_col_view_slice;

--- a/src/df/state.rs
+++ b/src/df/state.rs
@@ -185,7 +185,10 @@ impl DataFrameState {
             ).min(MAX_ROWS_RENDERED as u16);
 
         let cols_renderable =
-            (((table_area[1] / config_state.cell_width)as f64).floor() as u16).min(MAX_COLS_RENDERED as u16);
+            ((
+                (table_area[1] / config_state.cell_width) as f64)
+                .floor() as u16
+            ).min(MAX_COLS_RENDERED as u16);
 
         let (table_rows, table_cols) = self.get_df_shape();
         self.rows_rendered = rows_renderable

--- a/src/df/state.rs
+++ b/src/df/state.rs
@@ -185,7 +185,7 @@ impl DataFrameState {
             .min(MAX_ROWS_RENDERED as u16);
 
         let cols_renderable =
-            ((table_area[1] / config_state.cell_width)-minus_one_for_good_luck_because_it_needs_padding).min(MAX_COLS_RENDERED as u16);
+            (((table_area[1] / config_state.cell_width)as f64).floor() as u16).min(MAX_COLS_RENDERED as u16);
 
         self.rows_rendered = rows_renderable;
         self.cols_rendered = cols_renderable;
@@ -221,9 +221,11 @@ impl DataFrameState {
             curr_col_view_slice[0],
             (curr_col_view_slice[0]+self.rows_rendered).min(max_cols_in_table),
         ];
-        self.row_view_slice = new_row_view_slice;
-        self.col_view_slice = new_col_view_slice;
-
+        // self.row_view_slice = new_row_view_slice;
+        // self.col_view_slice = new_col_view_slice;
+        self.set_col_view_slice(new_col_view_slice);
+        self.set_row_view_slice(new_row_view_slice);
+        println!("rendered {},{}", self.rows_rendered, self.cols_rendered);
         // bound the cursors to be the upper bound
         // no need to do for lower bound since its lower bound centric
         // meaning its impossible for the lower bound to be mutated in

--- a/src/io/excel/page_widget.rs
+++ b/src/io/excel/page_widget.rs
@@ -49,13 +49,9 @@ impl ExcelSheetSelectorPage {
         let mut para = Paragraph::new(sheet_name).alignment(Alignment::Center);
 
         if is_selected {
-            para = para
-                .fg(Color::White)
-                .bg(Color::DarkGray);
+            para = para.fg(Color::White).bg(Color::DarkGray);
         } else {
-            para = para
-                .fg(Color::Black)
-                .bg(Color::Gray);
+            para = para.fg(Color::Black).bg(Color::Gray);
         }
 
         para.render(main, buf);

--- a/src/io/excel/page_widget.rs
+++ b/src/io/excel/page_widget.rs
@@ -7,7 +7,7 @@ use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Constraint, Layout, Rect},
     style::{Color, Stylize},
-    widgets::{Block, Borders, Paragraph, StatefulWidget, Widget, Wrap},
+    widgets::{Paragraph, StatefulWidget, Widget, Wrap},
 };
 
 ///////////

--- a/src/io/excel/reader.rs
+++ b/src/io/excel/reader.rs
@@ -4,7 +4,7 @@
 // csv string buffer.
 // then pass the cursor into polars dataframe.
 
-use std::{cell, io::Cursor};
+use std::io::Cursor;
 
 // use polars::error::PolarsError;
 use calamine::{Reader, Sheets, open_workbook_auto_from_rs};

--- a/src/io/gcloud.rs
+++ b/src/io/gcloud.rs
@@ -1,6 +1,5 @@
-use std::fs::File;
 
-use polars::{frame::DataFrame, prelude::*};
+use polars::prelude::*;
 
 use crate::errors::DoraErrors;
 use google_cloud_storage::client::{Client, ClientConfig};

--- a/src/io/handler.rs
+++ b/src/io/handler.rs
@@ -1,11 +1,7 @@
-use std::fs::File;
 
 use polars::{frame::DataFrame, prelude::*};
 
 use crate::errors::DoraErrors;
-use google_cloud_storage::client::{Client, ClientConfig};
-use google_cloud_storage::http::objects::download::Range;
-use google_cloud_storage::http::objects::get::GetObjectRequest;
 use std::io::Cursor;
 
 use super::excel::ExcelReader;

--- a/src/io/handler.rs
+++ b/src/io/handler.rs
@@ -14,10 +14,7 @@ use super::gcloud::read_bytes_from_gcs_sync;
 use super::local::read_bytes_from_local_sync;
 use super::path_location::PathLocation;
 
-
-pub fn read_from_any_path(
-    path: &str,
-) -> Result<DataFrame, DoraErrors> {
+pub fn read_from_any_path(path: &str) -> Result<DataFrame, DoraErrors> {
     let location = PathLocation::determine_location(path);
     let extension = match FileType::determine_extension(path) {
         Some(res) => res,
@@ -44,11 +41,12 @@ pub fn read_from_any_path(
             .with_json_format(JsonFormat::JsonLines)
             .finish()
             .map_err(|e| DoraErrors::IOError(e.to_string()))?,
-            
+
         FileType::Excel => {
-            panic!("Excel files should not be read using this function, the developer did a whoopsie!");
-        }
-        // _ => return Err(DoraErrors::FileNotFound("Invalid File Type".to_string())),
+            panic!(
+                "Excel files should not be read using this function, the developer did a whoopsie!"
+            );
+        } // _ => return Err(DoraErrors::FileNotFound("Invalid File Type".to_string())),
     });
 }
 
@@ -65,13 +63,9 @@ pub fn get_cursor_from_any_path(path: &str) -> Result<Cursor<Vec<u8>>, DoraError
 // excel sheets shouldnt be read
 // from read_from_any_path
 // since you need to provide an additional argument
-pub fn read_excel_from_any_path(
-    path: &str,
-    sheet_index: usize,
-) -> Result<DataFrame, DoraErrors> {
+pub fn read_excel_from_any_path(path: &str, sheet_index: usize) -> Result<DataFrame, DoraErrors> {
     let cursor = get_cursor_from_any_path(path)?;
-    
-    let df = ExcelReader::new(cursor)
-        .read_sheet(sheet_index)?;
+
+    let df = ExcelReader::new(cursor).read_sheet(sheet_index)?;
     Ok(df)
 }

--- a/src/io/local.rs
+++ b/src/io/local.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File,
-    io::{Bytes, Cursor, Read},
+    io::{Cursor, Read},
     path::Path,
 };
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -8,4 +8,4 @@ mod path_location;
 pub use excel::ExcelReader;
 pub use excel::page_widget::{ExcelSheetSelectorPage, ExcelSheetSelectorWidgetState};
 pub use file_type::FileType;
-pub use handler::{get_cursor_from_any_path, read_from_any_path, read_excel_from_any_path};
+pub use handler::{get_cursor_from_any_path, read_excel_from_any_path, read_from_any_path};

--- a/src/io/path_location.rs
+++ b/src/io/path_location.rs
@@ -1,12 +1,6 @@
-use std::fs::File;
 
-use polars::{frame::DataFrame, prelude::*};
+use polars::prelude::*;
 
-use crate::errors::DoraErrors;
-use google_cloud_storage::client::{Client, ClientConfig};
-use google_cloud_storage::http::objects::download::Range;
-use google_cloud_storage::http::objects::get::GetObjectRequest;
-use std::io::Cursor;
 
 const GS_PREFIX: &str = "gs://";
 

--- a/src/search/controller.rs
+++ b/src/search/controller.rs
@@ -4,12 +4,12 @@ pub fn shift_current_result_cursor_value_into_view(app_state: &mut App) {
     // shift the cursor value into view
     let result_cursor = app_state.search_result_state.result_cursor.unwrap();
     let result_location = app_state.search_result_state.result_indices[result_cursor].0;
-    shift_displayed_df_row_to_a_particular_index(app_state, result_location as i64)
+    shift_displayed_df_row_to_a_particular_index(app_state, result_location as u16)
 }
 
-pub fn shift_displayed_df_row_to_a_particular_index(app_state: &mut App, index: i64) {
+pub fn shift_displayed_df_row_to_a_particular_index(app_state: &mut App, index: u16) {
     // TODO: handle out of bounds
     let df_state = &mut app_state.dataframe_state;
-    let new_view = [index, index + (df_state.rows_rendered as i64)];
+    let new_view = [index, index + (df_state.rows_rendered as u16)];
     df_state.set_row_view_slice(new_view);
 }

--- a/src/table/column_ui.rs
+++ b/src/table/column_ui.rs
@@ -5,7 +5,7 @@ use ratatui::{
 };
 
 use crate::{
-    any_datetime, any_float, any_int, any_string, any_uint, app::App, df::state::CursorFocus,
+    app::App, df::state::CursorFocus,
     mode::AppMode, utils::cell::get_cell_area,
 };
 // NOTE: will never add the header to column, since I dont want to be able to navigate to

--- a/src/table/column_ui.rs
+++ b/src/table/column_ui.rs
@@ -98,7 +98,7 @@ impl ColumnUI {
     fn is_search_result(
         column_index: u16,
         search_results_found_in_row: &Vec<usize>,
-        absolute_row_index: i64,
+        absolute_row_index: u16,
         state: &<ColumnUI as StatefulWidget>::State,
     ) -> bool {
         match state.input_handler.mode_state {
@@ -148,7 +148,7 @@ impl StatefulWidget for ColumnUI {
         let series = column
             .as_series()
             .unwrap()
-            .slice(*val_offset_start, length_taken)
+            .slice(*val_offset_start as i64, length_taken)
             .rechunk(); // added because of bug: https://github.com/fafnirZ/dora/issues/1
         let search_results = &state.search_result_state.result_indices;
 
@@ -161,7 +161,7 @@ impl StatefulWidget for ColumnUI {
         // so for search result indices which is an absolute index w.r.t.
         // the full size of the column this will be erroneous.
         for (idx, value) in series.iter().enumerate() {
-            let absolute_row_index = val_offset_start + (idx as i64);
+            let absolute_row_index = val_offset_start + (idx as u16);
 
             let x = start_x + self.column_index * config_state.cell_width; // WELL depends on what the x_offset is for this column.
 

--- a/src/table/controller.rs
+++ b/src/table/controller.rs
@@ -4,12 +4,12 @@
 
 use crate::app::App;
 
+const STEP_SIZE: u16 = 1;
 
 // the following 4 functions does the following:
 // update the data slice for dataframe rows being
 // displayed.
 pub fn shift_displayed_df_value_slice_down(app_state: &mut App) {
-    let increment_value = 1;
     // TODO: handle out of bounds
     // NOTE: oob doesnt matter, polars.slice wraps around YAY!
     let df_state = &mut app_state.dataframe_state;
@@ -19,42 +19,39 @@ pub fn shift_displayed_df_value_slice_down(app_state: &mut App) {
         return;
     }
     let sliding_window_increment = [
-        curr_view[0] + increment_value,
-        curr_view[1] + increment_value,
+        curr_view[0] + STEP_SIZE,
+        curr_view[1] + STEP_SIZE,
     ];
     df_state.set_row_view_slice(sliding_window_increment);
 }
 
 pub fn shift_displayed_df_value_slice_up(app_state: &mut App) {
-    let increment_value = -1;
     let df_state = &mut app_state.dataframe_state;
     let curr_view = df_state.get_row_view_slice();
     if curr_view[0] == 0 {
         return;
     }
     let sliding_window_increment = [
-        curr_view[0] + increment_value,
-        curr_view[1] + increment_value,
+        curr_view[0] - STEP_SIZE,
+        curr_view[1] - STEP_SIZE,
     ];
     df_state.set_row_view_slice(sliding_window_increment);
 }
 
 pub fn shift_displayed_df_value_slice_left(app_state: &mut App) {
-    let increment_value = -1;
     let df_state = &mut app_state.dataframe_state;
     let curr_view = df_state.get_col_view_slice();
     if curr_view[0] == 0 {
         return;
     }
     let sliding_window_increment = [
-        curr_view[0] + increment_value,
-        curr_view[1] + increment_value,
+        curr_view[0] - STEP_SIZE,
+        curr_view[1] - STEP_SIZE,
     ];
     df_state.set_col_view_slice(sliding_window_increment);
 }
 
 pub fn shift_displayed_df_value_slice_right(app_state: &mut App) {
-    let increment_value = 1;
     let df_state = &app_state.dataframe_state;
     let df_col_len = df_state.get_df_shape().1;
     let df_state = &mut app_state.dataframe_state;
@@ -63,8 +60,8 @@ pub fn shift_displayed_df_value_slice_right(app_state: &mut App) {
         return;
     }
     let sliding_window_increment = [
-        curr_view[0] + increment_value,
-        curr_view[1] + increment_value,
+        curr_view[0] + STEP_SIZE,
+        curr_view[1] + STEP_SIZE,
     ];
     df_state.set_col_view_slice(sliding_window_increment);
 }
@@ -72,7 +69,6 @@ pub fn shift_displayed_df_value_slice_right(app_state: &mut App) {
 // the following four functions update the table cursors
 
 pub fn shift_row_cursor_down(app_state: &mut App) {
-    let increment_value = 1;
     // TODO: handle out of bounds
     let df_state = &mut app_state.dataframe_state;
 
@@ -81,11 +77,10 @@ pub fn shift_row_cursor_down(app_state: &mut App) {
     if *curr_y >= df_row_len {
         return;
     }
-    df_state.set_cursor_y(curr_y + increment_value);
+    df_state.set_cursor_y(curr_y + STEP_SIZE);
 }
 
 pub fn shift_row_cursor_up(app_state: &mut App) {
-    let increment_value = -1;
     // TODO: handle out of bounds
     let df_state = &mut app_state.dataframe_state;
 
@@ -93,22 +88,20 @@ pub fn shift_row_cursor_up(app_state: &mut App) {
     if *curr_y <= 0 {
         return;
     }
-    df_state.set_cursor_y(curr_y + increment_value);
+    df_state.set_cursor_y(curr_y - STEP_SIZE);
 }
 
 pub fn shift_column_cursor_left(app_state: &mut App) {
-    let increment_value = -1;
     // TODO: handle out of bounds
     let df_state = &mut app_state.dataframe_state;
     let curr_x = df_state.get_cursor_x();
     if *curr_x <= 0 {
         return;
     }
-    df_state.set_cursor_x(curr_x + increment_value);
+    df_state.set_cursor_x(curr_x - STEP_SIZE);
 }
 
 pub fn shift_column_cursor_right(app_state: &mut App) {
-    let increment_value = 1;
     // TODO: handle out of bounds
     let df_state = &mut app_state.dataframe_state;
 
@@ -117,5 +110,5 @@ pub fn shift_column_cursor_right(app_state: &mut App) {
     if *curr_x >= df_col_len - 1 {
         return;
     }
-    df_state.set_cursor_x(curr_x + increment_value);
+    df_state.set_cursor_x(curr_x + STEP_SIZE);
 }

--- a/src/table/controller.rs
+++ b/src/table/controller.rs
@@ -4,6 +4,7 @@
 
 use crate::app::App;
 
+
 // the following 4 functions does the following:
 // update the data slice for dataframe rows being
 // displayed.

--- a/src/table/controller.rs
+++ b/src/table/controller.rs
@@ -56,7 +56,7 @@ pub fn shift_displayed_df_value_slice_right(app_state: &mut App) {
     let df_col_len = df_state.get_df_shape().1;
     let df_state = &mut app_state.dataframe_state;
     let curr_view = df_state.get_col_view_slice();
-    if curr_view[1] >= df_col_len - 1 {
+    if curr_view[1] > df_col_len {
         return;
     }
     let sliding_window_increment = [
@@ -107,7 +107,7 @@ pub fn shift_column_cursor_right(app_state: &mut App) {
 
     let df_col_len = df_state.get_df_shape().1;
     let curr_x = df_state.get_cursor_x();
-    if *curr_x >= df_col_len - 1 {
+    if *curr_x >= df_col_len {
         return;
     }
     df_state.set_cursor_x(curr_x + STEP_SIZE);

--- a/src/table/controller.rs
+++ b/src/table/controller.rs
@@ -18,10 +18,7 @@ pub fn shift_displayed_df_value_slice_down(app_state: &mut App) {
     if curr_view[1] == df_row_len {
         return;
     }
-    let sliding_window_increment = [
-        curr_view[0] + STEP_SIZE,
-        curr_view[1] + STEP_SIZE,
-    ];
+    let sliding_window_increment = [curr_view[0] + STEP_SIZE, curr_view[1] + STEP_SIZE];
     df_state.set_row_view_slice(sliding_window_increment);
 }
 
@@ -31,10 +28,7 @@ pub fn shift_displayed_df_value_slice_up(app_state: &mut App) {
     if curr_view[0] == 0 {
         return;
     }
-    let sliding_window_increment = [
-        curr_view[0] - STEP_SIZE,
-        curr_view[1] - STEP_SIZE,
-    ];
+    let sliding_window_increment = [curr_view[0] - STEP_SIZE, curr_view[1] - STEP_SIZE];
     df_state.set_row_view_slice(sliding_window_increment);
 }
 
@@ -44,10 +38,7 @@ pub fn shift_displayed_df_value_slice_left(app_state: &mut App) {
     if curr_view[0] == 0 {
         return;
     }
-    let sliding_window_increment = [
-        curr_view[0] - STEP_SIZE,
-        curr_view[1] - STEP_SIZE,
-    ];
+    let sliding_window_increment = [curr_view[0] - STEP_SIZE, curr_view[1] - STEP_SIZE];
     df_state.set_col_view_slice(sliding_window_increment);
 }
 
@@ -59,10 +50,7 @@ pub fn shift_displayed_df_value_slice_right(app_state: &mut App) {
     if curr_view[1] > df_col_len {
         return;
     }
-    let sliding_window_increment = [
-        curr_view[0] + STEP_SIZE,
-        curr_view[1] + STEP_SIZE,
-    ];
+    let sliding_window_increment = [curr_view[0] + STEP_SIZE, curr_view[1] + STEP_SIZE];
     df_state.set_col_view_slice(sliding_window_increment);
 }
 


### PR DESCRIPTION
sometimes it works sometimes it doesnt,

theres major updates in how `view-slice` works in this PR, i.e. reworked it from being cursor centric logic to being `lower bound of view slice` as source of truth.

cursors may be outside of viewslice bounds when cell sizes update which causes a plethora of bugs, whereas the viewslice lowerbound shouldnt update?