### PR TITLE
feat: adding `shift+j/k` for navigating up and down quicker (3 lines)

### DIFF
--- a/dora-explorer/src/library/control.rs
+++ b/dora-explorer/src/library/control.rs
@@ -1,7 +1,9 @@
 
 pub enum Control {
     ScrollUp,
+    ExtendedScrollUp,
     ScrollDown,
+    ExtendedScrollDown,
     ScrollLeft,
     ScrollRight,
     ToggleShowDotFiles,

--- a/dora-explorer/src/library/controller.rs
+++ b/dora-explorer/src/library/controller.rs
@@ -220,14 +220,24 @@ impl Controller {
     fn scroll_up(n: u16, state: &mut ExplorerState) {
         let cursor_pos = &state.cursor_y;
         if *cursor_pos == 0 {
-            let [start,end] = &state.view_slice;
+            let [start,_] = &state.view_slice;
             if *start == 0 {
                 return;
             } else {
-                // mutate to slide up 1
+                // mutate to slide up n
+                // prevent overflow
+                let view_start = {
+                    if ((start-n) as i16) < 0  {
+                        0
+                    } else {
+                        start -n
+                    }
+                };
+                let num_renderable = &state.recalculate_renderable_rows();
+                let view_end = view_start + num_renderable; 
                 state.view_slice = [
-                    start-n,
-                    end-n,
+                    view_start,
+                    view_end,
                 ]
             }
         } else {

--- a/dora-explorer/src/library/controller.rs
+++ b/dora-explorer/src/library/controller.rs
@@ -4,6 +4,8 @@ use crossterm::cursor;
 
 use super::{control::Control, filter::ExactSubstringSearch, input::InputBuffer, mode::Mode, navigator::{self, gcs::GCSNavigator, local::LocalNavigator, traits::{AnyNavigator, Navigator}, types::{DEnt, FileType}}, ExplorerState};
 
+const EXTENDED_SCROLL_SIZE: u16 = 3;
+
 // given input,
 // take a look at current state
 // mutate state according to input
@@ -48,41 +50,16 @@ impl Controller {
                 }
             },
             Control::ScrollUp => {
-                let cursor_pos = &state.cursor_y;
-                if *cursor_pos == 0 {
-                    let [start,end] = &state.view_slice;
-                    if *start == 0 {
-                        return;
-                    } else {
-                        // mutate to slide up 1
-                        state.view_slice = [
-                            start-1,
-                            end-1,
-                        ]
-                    }
-                } else {
-                    state.cursor_y -= 1;
-                }
+                Controller::scroll_up(1, state);
             }
             Control::ScrollDown => {
-                let cursor_pos = &state.cursor_y;
-                let num_dents = &state.get_dents_auto().len();
-                let num_renderable = &state.recalculate_renderable_rows();
-                if *cursor_pos == *num_renderable-1 {
-                    let [start,end] = &state.view_slice;
-                    if *end == (*num_dents as u16) {
-                        return;
-                    } else {
-                        // slide down 1
-                        state.view_slice = [
-                            *start+1,
-                            *end+1,
-                        ]
-                    }
-                }
-                else {
-                    state.cursor_y += 1;
-                }
+                Controller::scroll_down(1, state);
+            }
+            Control::ExtendedScrollUp=> {
+                Controller::scroll_up(EXTENDED_SCROLL_SIZE, state);
+            }
+            Control::ScrollDown => {
+                Controller::scroll_down(EXTENDED_SCROLL_SIZE, state);
             }
             Control::ScrollRight => {
 
@@ -213,6 +190,48 @@ impl Controller {
 
                 state.recalculate_view_slice();
             }
+        }
+    }
+}
+
+impl Controller {
+
+    fn scroll_down(n: u16, state: &mut ExplorerState) {
+        let cursor_pos = &state.cursor_y;
+        let num_dents = &state.get_dents_auto().len();
+        let num_renderable = &state.recalculate_renderable_rows();
+        if *cursor_pos == *num_renderable-1 {
+            let [start,end] = &state.view_slice;
+            if *end == (*num_dents as u16) {
+                return;
+            } else {
+                // slide down 1
+                state.view_slice = [
+                    *start+n,
+                    *end+n,
+                ]
+            }
+        }
+        else {
+            state.cursor_y += n;
+        }
+    }
+
+    fn scroll_up(n: u16, state: &mut ExplorerState) {
+        let cursor_pos = &state.cursor_y;
+        if *cursor_pos == 0 {
+            let [start,end] = &state.view_slice;
+            if *start == 0 {
+                return;
+            } else {
+                // mutate to slide up 1
+                state.view_slice = [
+                    start-n,
+                    end-n,
+                ]
+            }
+        } else {
+            state.cursor_y -= n;
         }
     }
 }

--- a/dora-explorer/src/library/controller.rs
+++ b/dora-explorer/src/library/controller.rs
@@ -227,10 +227,10 @@ impl Controller {
                 // mutate to slide up n
                 // prevent overflow
                 let view_start = {
-                    if ((start-n) as i16) < 0  {
+                    if *start < n { // need to do this way in order to prevent u16 subtraction overflow
                         0
                     } else {
-                        start -n
+                        start-n
                     }
                 };
                 let num_renderable = &state.recalculate_renderable_rows();
@@ -241,7 +241,13 @@ impl Controller {
                 ]
             }
         } else {
-            state.cursor_y -= n;
+            state.cursor_y = {
+                if *cursor_pos < n {
+                    0
+                } else {
+                    *cursor_pos - n
+                }
+            };
         }
     }
 }

--- a/dora-explorer/src/library/controller.rs
+++ b/dora-explorer/src/library/controller.rs
@@ -55,10 +55,10 @@ impl Controller {
             Control::ScrollDown => {
                 Controller::scroll_down(1, state);
             }
-            Control::ExtendedScrollUp=> {
+            Control::ExtendedScrollUp => {
                 Controller::scroll_up(EXTENDED_SCROLL_SIZE, state);
             }
-            Control::ScrollDown => {
+            Control::ExtendedScrollDown => {
                 Controller::scroll_down(EXTENDED_SCROLL_SIZE, state);
             }
             Control::ScrollRight => {

--- a/dora-explorer/src/library/controller.rs
+++ b/dora-explorer/src/library/controller.rs
@@ -213,7 +213,13 @@ impl Controller {
             }
         }
         else {
-            state.cursor_y += n;
+            state.cursor_y = {
+                if cursor_pos + n > *num_renderable-1 {
+                    *num_renderable-1
+                } else {
+                    cursor_pos + n
+                }
+            };
         }
     }
 

--- a/dora-explorer/src/library/input/input.rs
+++ b/dora-explorer/src/library/input/input.rs
@@ -67,8 +67,8 @@ impl InputHandler {
                 _ => Control::Nothing,
             },
             KeyModifiers::SHIFT => match key_event.code {
-                KeyCode::Char('k') | KeyCode::Up => Control::ExtendedScrollUp,
-                KeyCode::Char('j') | KeyCode::Down => Control::ExtendedScrollDown,
+                KeyCode::Char('K') | KeyCode::Up => Control::ExtendedScrollUp,
+                KeyCode::Char('J') | KeyCode::Down => Control::ExtendedScrollDown,
                 _ => Control::Nothing,
             },
             KeyModifiers::CONTROL => match key_event.code {

--- a/dora-explorer/src/library/input/input.rs
+++ b/dora-explorer/src/library/input/input.rs
@@ -67,6 +67,8 @@ impl InputHandler {
                 _ => Control::Nothing,
             },
             KeyModifiers::SHIFT => match key_event.code {
+                KeyCode::Char('k') | KeyCode::Up => Control::ExtendedScrollUp,
+                KeyCode::Char('j') | KeyCode::Down => Control::ExtendedScrollDown,
                 _ => Control::Nothing,
             },
             KeyModifiers::CONTROL => match key_event.code {


### PR DESCRIPTION
closes #66 