### PR TITLE
feat: adding `DORA_NOSELECT_FILE=1` environment variable which allows `cde` to not select files which breaks functionality

### DIFF
--- a/dora-explorer/README.md
+++ b/dora-explorer/README.md
@@ -9,7 +9,7 @@ It provides local file navigation support as well as GCS File path selection sup
 to perform navigation with the dora explorer binary, paste the following function into your `~/.bashrc`
 
 ```
-cde() { cd $(de $@); }
+cde() { DORA_NOSELECT_FILE=1 cd $(de $@); }
 ```
 
 ## How to navigate the explorer

--- a/dora-explorer/src/library/controller.rs
+++ b/dora-explorer/src/library/controller.rs
@@ -121,6 +121,11 @@ impl Controller {
                         }
                     },
                     FileType::File => {
+                        if state.config_no_select_file {
+                            // we don't want to select files in this mode
+                            // so we just return #75
+                            return
+                        }
                         // exit program and return file path
                         state.sig_file_selected_exit = true;
                     },

--- a/dora-explorer/src/library/state.rs
+++ b/dora-explorer/src/library/state.rs
@@ -33,6 +33,11 @@ pub struct ExplorerState{
     // when these gets flagged, it will exit.
     pub sig_user_input_exit: bool,
     pub sig_file_selected_exit: bool,
+
+
+    // global flags
+    // which configure behaviour
+    pub config_no_select_file: bool,
 }
 
 impl ExplorerState {
@@ -78,6 +83,7 @@ impl ExplorerState {
             sig_file_selected_exit: false,
             input_handler: InputHandler::new(),
             mode: Mode::Normal,
+            config_no_select_file: false,
         }
     }
 
@@ -89,6 +95,16 @@ impl ExplorerState {
             .into_iter()
             .filter(|entry | filter_dot_dent(&entry))
             .collect();
+
+        let should_select_files = {
+            match env::var("DORA_NOSELECT_FILE") {
+                Ok(val) => {
+                    // Use `&val` to get a `&str` from the `String`
+                    vec!["1", "True", "true"].contains(&val.as_str())
+                },
+                Err(_) => false,
+            }
+        };
 
         return Self {
             cwd: AnyPath::LocalPath(path.to_path_buf()), // cwd
@@ -104,6 +120,7 @@ impl ExplorerState {
             sig_file_selected_exit: false,
             input_handler: InputHandler::new(),
             mode: Mode::Normal,
+            config_no_select_file: should_select_files,
         }
     }
 


### PR DESCRIPTION
half implements #75